### PR TITLE
chore: moving MAX_RETRY_TIMES to constanst

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ npm install --save @copicake/copicake-js
 ## For yarn user
 
 ```bash
-yarn add @copicake/copicake-js --dev
+yarn add @copicake/copicake-js
 ```
 
 # Usage
@@ -81,7 +81,7 @@ Sometimes you may notice that your image is still under `processing` state, this
 
 In this way, we provide another handy method called `getUntilFinished()` to get the image until the image is ready.
 
-Internally, this is just a wrapper of `get()` method with built-in retry mechanism. If after MAX_RETRY_TIMES and the image is still under `processing` state, we will throw an error (500) to let you know.
+Internally, this is just a wrapper of `get()` method with built-in retry mechanism. If after `MAX_RETRY_TIMES` and the image is still under `processing` state, we will throw an error (500) to let you know.
 
 ```js
 const renderingId = `YOUR_RENDERING_ID`;

--- a/src/lib/constant.ts
+++ b/src/lib/constant.ts
@@ -3,3 +3,5 @@ export const API_END_POINT = "https://api.copicake.com/v1";
 export const IMAGE_API_END_POINT = `${API_END_POINT}/image`;
 
 export const RETRY_TIMEOUT = 1000;
+
+export const MAX_RETRY_TIMES = 10;

--- a/src/lib/image.ts
+++ b/src/lib/image.ts
@@ -1,10 +1,9 @@
 import unfetch from "isomorphic-unfetch";
 import { Rendering, Change, Options } from "../types/Rendering";
-import { IMAGE_API_END_POINT, RETRY_TIMEOUT } from "./constant";
+import { IMAGE_API_END_POINT, RETRY_TIMEOUT, MAX_RETRY_TIMES } from "./constant";
 
 // Bug: Failed to execute 'fetch' on 'Window': Illegal invocation
 const fetch = unfetch.bind(self);
-const MAX_RETRY_TIMES = 10;
 
 interface ICreate {
   template_id: string;


### PR DESCRIPTION
## Description

- Moving `MAX_RETRY_TIMES` to constant file
- Highlight `MAX_RETRY_TIMES` and update the installation script